### PR TITLE
Creating a new data source plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ and all its associated data.
 Chartmogul::Import::Customer.delete(uuid: "customer_uuid")
 ```
 
+### Plans
+
+This object represents a subscription billing plan for products or services that
+you offer your customers. For example, you might have a $50 monthly plan with a
+set of features, and a $500 annual plan.
+
+#### Import a Plan
+
+Create a `plan` object in ChartMogul under the specified `data_source`.
+
+```ruby
+Chartmogul::Import::Plan.create(plan_attributes = {})
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -1,7 +1,9 @@
 require "chartmogul/version"
 require "chartmogul/client"
+require "chartmogul/import/base"
 require "chartmogul/import/data_source"
 require "chartmogul/import/customer"
+require "chartmogul/import/plan"
 
 module Chartmogul
 end

--- a/lib/chartmogul/import/base.rb
+++ b/lib/chartmogul/import/base.rb
@@ -1,0 +1,30 @@
+module Chartmogul
+  module Import
+    class Base
+      def create(attributes)
+        if required_keys_exist?(attributes)
+          Chartmogul.post_resource(["import", end_point].join("/"), attributes)
+        else
+          raise ArgumentError.new("Required keys: " + required_keys.join(", "))
+        end
+      end
+
+      def self.method_missing(method_name, *arguments, &block)
+        resource = new
+        if resource.respond_to?(method_name, include_private: false)
+          resource.send(method_name, *arguments, &block)
+        end
+      end
+
+      private
+
+      def required_keys
+        nil
+      end
+
+      def required_keys_exist?(attributes)
+        !required_keys.map { |key| attributes.include?(key) }.include?(false)
+      end
+    end
+  end
+end

--- a/lib/chartmogul/import/plan.rb
+++ b/lib/chartmogul/import/plan.rb
@@ -1,0 +1,15 @@
+module Chartmogul
+  module Import
+    class Plan < Base
+      private
+
+      def end_point
+        "plans"
+      end
+
+      def required_keys
+        [:name, :interval_count, :interval_unit, :data_source_uuid]
+      end
+    end
+  end
+end

--- a/spec/chartmogul/import/plan_spec.rb
+++ b/spec/chartmogul/import/plan_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+describe Chartmogul::Import::Plan do
+  describe ".create" do
+    it "creates a new plan" do
+      plan_attributes = {
+        data_source_uuid: "ds_uuid_001",
+        name: "Bronze Plan",
+        interval_count: 1,
+        interval_unit: "month",
+        external_id: "plan_001"
+      }
+
+      stub_plan_create_api(plan_attributes)
+      plan = Chartmogul::Import::Plan.create(plan_attributes)
+
+      expect(plan.uuid).not_to be_nil
+      expect(plan.name).to eq(plan_attributes[:name])
+      expect(plan.data_source_uuid).to eq(plan_attributes[:data_source_uuid])
+    end
+  end
+end

--- a/spec/fixtures/plan_created.json
+++ b/spec/fixtures/plan_created.json
@@ -1,0 +1,8 @@
+{
+  "uuid": "pl_eed05d54-75b4-431b",
+  "data_source_uuid": "ds_uuid_001",
+  "name": "Bronze Plan",
+  "interval_count": 1,
+  "interval_unit": "month",
+  "external_id": "plan_0001"
+}

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -52,6 +52,16 @@ module FakeChartmogulApi
     )
   end
 
+  def stub_plan_create_api(plan_attributes)
+    stub_api_response(
+      :post,
+      "import/plans",
+      data: plan_attributes,
+      filename: "plan_created",
+      status: 201
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status: 200, data: nil)


### PR DESCRIPTION
This commit allow you to create a plan object in ChartMogul under the specified data_source. Usages:
```ruby
Chartmogul::Import::Plan.create(plan_attributes = {})
```