### PR TITLE
Cleanup importing duplications

### DIFF
--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -1,9 +1,6 @@
 require "chartmogul/version"
 require "chartmogul/client"
-require "chartmogul/import/base"
-require "chartmogul/import/data_source"
-require "chartmogul/import/customer"
-require "chartmogul/import/plan"
+require "chartmogul/import"
 
 module Chartmogul
 end

--- a/lib/chartmogul/import.rb
+++ b/lib/chartmogul/import.rb
@@ -1,0 +1,9 @@
+require "chartmogul/import/base"
+require "chartmogul/import/plan"
+require "chartmogul/import/customer"
+require "chartmogul/import/data_source"
+
+module Chartmogul
+  module Import
+  end
+end

--- a/lib/chartmogul/import/base.rb
+++ b/lib/chartmogul/import/base.rb
@@ -1,12 +1,20 @@
 module Chartmogul
   module Import
     class Base
+      def list(options = {})
+        Chartmogul.get_resource(resource_end_point, options)
+      end
+
       def create(attributes)
         if required_keys_exist?(attributes)
-          Chartmogul.post_resource(["import", end_point].join("/"), attributes)
+          Chartmogul.post_resource(resource_end_point, attributes)
         else
           raise ArgumentError.new("Required keys: " + required_keys.join(", "))
         end
+      end
+
+      def delete(uuid:)
+        Chartmogul.delete_resource([resource_end_point, uuid].join("/"))
       end
 
       def self.method_missing(method_name, *arguments, &block)
@@ -18,12 +26,16 @@ module Chartmogul
 
       private
 
-      def required_keys
-        nil
+      def resource_end_point
+        ["import", end_point].compact.join("/")
       end
 
       def required_keys_exist?(attributes)
         !required_keys.map { |key| attributes.include?(key) }.include?(false)
+      end
+
+      def required_keys
+        []
       end
     end
   end

--- a/lib/chartmogul/import/customer.rb
+++ b/lib/chartmogul/import/customer.rb
@@ -1,24 +1,14 @@
 module Chartmogul
   module Import
-    class Customer
-      def self.create(name:, external_id:, data_source_uuid:, **args)
-        required_parameters = {
-          name: name,
-          external_id: external_id,
-          data_source_uuid: data_source_uuid
-        }
+    class Customer < Base
+      private
 
-        Chartmogul.post_resource(
-          "import/customers", required_parameters.merge(args)
-        )
+      def end_point
+        "customers"
       end
 
-      def self.list(options = {})
-        Chartmogul.get_resource "import/customers", options
-      end
-
-      def self.delete(uuid:)
-        Chartmogul.delete_resource ["import/customers", uuid].join("/")
+      def required_keys
+        [:name, :external_id, :data_source_uuid]
       end
     end
   end

--- a/lib/chartmogul/import/data_source.rb
+++ b/lib/chartmogul/import/data_source.rb
@@ -1,16 +1,14 @@
 module Chartmogul
   module Import
-    class DataSource
-      def self.list
-        Chartmogul.get_resource "import/data_sources"
+    class DataSource < Base
+      private
+
+      def end_point
+        "data_sources"
       end
 
-      def self.create(name:)
-        Chartmogul.post_resource "import/data_sources", name: name
-      end
-
-      def self.delete(uuid:)
-        Chartmogul.delete_resource ["import/data_sources", uuid].join("/")
+      def required_keys
+        [:name]
       end
     end
   end


### PR DESCRIPTION
Pretty much every importing sub module is dealing with `list`, `create` and `delete` action and we are repeating it in each resource. Now that we added a `import/base`, so lets cleanup those duplications.