### PR TITLE
Listing all existing plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ Chartmogul::Import::Plan.create(
 )
 ```
 
+#### List Plans
+
+Retrieve a list of plan objects created using the Import API. Checkout
+[plan listing doc] for supported `listing_options`.
+
+```ruby
+Chartmogul::Import::Plan.list(listing_options = {})
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the
@@ -195,3 +204,4 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/[USERN
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
 
 [customer listing doc]: https://dev.chartmogul.com/docs/list-all-imported-customers
+[plan listing doc]: https://dev.chartmogul.com/docs/list-all-imported-plans

--- a/spec/chartmogul/import/plan_spec.rb
+++ b/spec/chartmogul/import/plan_spec.rb
@@ -19,4 +19,16 @@ describe Chartmogul::Import::Plan do
       expect(plan.data_source_uuid).to eq(plan_attributes[:data_source_uuid])
     end
   end
+
+  describe ".list" do
+    it "lists all the plans" do
+      listing_options = { page: 1, per_page: 3 }
+      stub_plan_list_api(listing_options)
+      plans = Chartmogul::Import::Plan.list(listing_options)
+
+      expect(plans.current_page).to eq(1)
+      expect(plans.plans.count).to eq(3)
+      expect(plans.plans.first.uuid).not_to be_nil
+    end
+  end
 end

--- a/spec/fixtures/plan_list.json
+++ b/spec/fixtures/plan_list.json
@@ -1,0 +1,30 @@
+{
+  "plans":[
+    {
+      "uuid": "pl_eed05d54-75b4",
+      "data_source_uuid": "ds_fef05d54",
+      "name": "Bronze Plan",
+      "interval_count": 1,
+      "interval_unit": "month",
+      "external_id": "plan_0001"
+    },
+    {
+      "uuid": "pl_cdb35d54-75b4",
+      "data_source_uuid": "ds_uuid_001",
+      "name": "Silver Plan",
+      "interval_count": 6,
+      "interval_unit": "month",
+      "external_id": "plan_0002"
+    },
+    {
+      "uuid": "pl_ab225d54-7ab4-421b",
+      "data_source_uuid": "ds_uuid_001",
+      "name": "Gold Plan",
+      "interval_count": 1,
+      "interval_unit": "year",
+      "external_id": "plan_0003"
+    }
+  ],
+  "current_page": 1,
+  "total_pages": 2
+}

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -36,11 +36,9 @@ module FakeChartmogulApi
   end
 
   def stub_customer_list_api(options)
-    options = options.map { |key, value| [key, value].join("=") }.join("&")
-
     stub_api_response(
       :get,
-      ["import/customers", options].join("?"),
+      ["import/customers", resource_params(options)].join("?"),
       filename: "customer_list",
       status: 200
     )
@@ -55,10 +53,19 @@ module FakeChartmogulApi
   def stub_plan_create_api(plan_attributes)
     stub_api_response(
       :post,
-      "import/plans",
+      plan_end_point,
       data: plan_attributes,
       filename: "plan_created",
       status: 201
+    )
+  end
+
+  def stub_plan_list_api(options)
+    stub_api_response(
+      :get,
+      [plan_end_point, resource_params(options)].join("?"),
+      filename: "plan_list",
+      status: 200
     )
   end
 
@@ -68,6 +75,14 @@ module FakeChartmogulApi
     stub_request(method, api_end_point(end_point)).
       with(api_request_headers(data: data)).
       to_return(response_with(filename: filename, status: status))
+  end
+
+  def resource_params(options)
+    options.map { |key, value| [key, value].join("=") }.join("&")
+  end
+
+  def plan_end_point
+    "import/plans"
   end
 
   def api_end_point(end_point)


### PR DESCRIPTION
Retrieve all existing subscription plans using the Import API, Usages:

```ruby
Chartmogul::Import::Plan.list(listing_options = {})
```