### PR TITLE
Create a new invoice transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,13 +206,34 @@ transaction_attributes = {
 }
 ```
 
-### List Customer's Invoices
+#### List Customer's Invoices
 
 List the invoices of a specified customer
 
 ```ruby
 Chartmogul::Import::Invoice.list(
   uuid: customer_uuid, page: 1, per_page: 20
+)
+```
+
+### Transactions
+
+This object represents a payment or refund attempt on an invoice. You can add
+any number of successful and failed transaction attempts on an invoice to
+ChartMogul. Transaction objects influence Cash Flow metrics in your ChartMogul
+account.
+
+#### Import an Invoice Transaction
+
+Create a new transaction object for an invoice imported using the Import API.
+
+```ruby
+Chartmogul::Import::Transaction.create(
+  type: "refund",
+  uuid: "invoice_001",
+  result: "successful",
+  date: "2015-12-25 18:10:00",
+  external_id: "transaction_001"
 )
 ```
 

--- a/lib/chartmogul/import.rb
+++ b/lib/chartmogul/import.rb
@@ -2,6 +2,7 @@ require "chartmogul/import/base"
 require "chartmogul/import/plan"
 require "chartmogul/import/invoice"
 require "chartmogul/import/customer"
+require "chartmogul/import/transaction"
 require "chartmogul/import/data_source"
 
 module Chartmogul

--- a/lib/chartmogul/import/transaction.rb
+++ b/lib/chartmogul/import/transaction.rb
@@ -1,0 +1,22 @@
+module Chartmogul
+  module Import
+    class Transaction < Base
+      attr_reader :invoice_uuid
+
+      def create(uuid:, **transaction_attributes)
+        @invoice_uuid = uuid
+        super(transaction_attributes)
+      end
+
+      private
+
+      def end_point
+        ["invoices", invoice_uuid, "transactions"].join("/")
+      end
+
+      def required_keys
+        [:type, :date, :result]
+      end
+    end
+  end
+end

--- a/spec/chartmogul/import/transaction_spec.rb
+++ b/spec/chartmogul/import/transaction_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe Chartmogul::Import::Transaction do
+  describe ".create" do
+    it "creates a new transaction for a invoice" do
+      transaction_attributes = {
+        type: "refund",
+        uuid: "invoice_001",
+        result: "successful",
+        date: "2015-12-25 18:10:00",
+        external_id: "transaction_001"
+      }
+
+      stub_transaction_create_api(transaction_attributes)
+      transaction = Chartmogul::Import::Transaction.create(
+        transaction_attributes
+      )
+
+      expect(transaction.uuid).not_to be_nil
+      expect(transaction.type).to eq(transaction_attributes[:type])
+      expect(transaction.result).to eq(transaction_attributes[:result])
+    end
+  end
+end

--- a/spec/fixtures/transaction_created.json
+++ b/spec/fixtures/transaction_created.json
@@ -1,0 +1,7 @@
+{
+  "uuid": "tr_325e460a-1bec",
+  "external_id": "transaction_001",
+  "type": "refund",
+  "date": "2015-12-25T18:10:00.000Z",
+  "result": "successful"
+}

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -88,6 +88,16 @@ module FakeChartmogulApi
     )
   end
 
+  def stub_transaction_create_api(uuid:, **attributes)
+    stub_api_response(
+      :post,
+      transaction_end_point(uuid),
+      data: attributes,
+      filename: "transaction_created",
+      status: 201
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status: 200, data: nil)
@@ -106,6 +116,10 @@ module FakeChartmogulApi
 
   def invoice_end_point(customer_uuid)
     ["import", "customers", customer_uuid, "invoices"].join("/")
+  end
+
+  def transaction_end_point(invoice_uuid)
+    ["import", "invoices", invoice_uuid, "transactions"].join("/")
   end
 
   def api_end_point(end_point)


### PR DESCRIPTION
This commit will allow us to create a transaction for a imported invoice. Usages:

```ruby
Chartmogul::Import::Transaction.create(
  type: "refund",
  uuid: "invoice_001",
  result: "successful",
  date: "2015-12-25 18:10:00",
  external_id: "transaction_001"
)
```