### PR TITLE
List customer's subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,24 @@ Chartmogul::Import::Transaction.create(
 )
 ```
 
+### Subscriptions
+
+Subscription objects are auto-generated from Invoice objects. In ChartMogul,
+customers can have multiple subscriptions at the same time. Subscriptions are
+created when a customer purchases a plan for the first time. They may be
+altered, cancelled and re-activated indefinitely.
+
+#### List Customer's Subscriptions
+
+Retrieve a list of `subscription` objects for a given `customer`. Subscriptions
+are auto-generated from invoice objects created using the Import API.
+
+```ruby
+Chartmogul::Import::Subscription.list(
+  uuid: "customer_uuid_001", page: 1, per_page: 10
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/import.rb
+++ b/lib/chartmogul/import.rb
@@ -2,8 +2,9 @@ require "chartmogul/import/base"
 require "chartmogul/import/plan"
 require "chartmogul/import/invoice"
 require "chartmogul/import/customer"
-require "chartmogul/import/transaction"
 require "chartmogul/import/data_source"
+require "chartmogul/import/transaction"
+require "chartmogul/import/subscription"
 
 module Chartmogul
   module Import

--- a/lib/chartmogul/import/subscription.rb
+++ b/lib/chartmogul/import/subscription.rb
@@ -1,0 +1,18 @@
+module Chartmogul
+  module Import
+    class Subscription < Base
+      attr_reader :customer_uuid
+
+      def list(uuid:, **listing_options)
+        @customer_uuid = uuid
+        super(listing_options)
+      end
+
+      private
+
+      def end_point
+        ["customers", customer_uuid, "subscriptions"].join("/")
+      end
+    end
+  end
+end

--- a/spec/chartmogul/import/subscription_spec.rb
+++ b/spec/chartmogul/import/subscription_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe Chartmogul::Import::Subscription do
+  describe ".list" do
+    it "lists customer subscriptions" do
+      listing_options = { uuid: "customer_001", page: 1, per_page: 1 }
+
+      stub_subscription_listing_api(listing_options)
+      subscriptions = Chartmogul::Import::Subscription.list(listing_options)
+
+      expect(subscriptions.current_page).to eq(1)
+      expect(subscriptions.subscriptions.first.uuid).not_to be_nil
+      expect(subscriptions.subscriptions.first.plan_uuid).not_to be_nil
+      expect(subscriptions.customer_uuid).to eq(listing_options[:uuid])
+    end
+  end
+end

--- a/spec/fixtures/subscription_list.json
+++ b/spec/fixtures/subscription_list.json
@@ -1,0 +1,14 @@
+{
+  "customer_uuid": "customer_001",
+  "subscriptions":[
+    {
+      "uuid": "sub_e6bc5407-e258-4de0-bb43",
+      "external_id": "sub_0001",
+      "plan_uuid": "pl_eed05d54-75b4-431b-adb2",
+      "data_source_uuid": "ds_fef05d54-47b4-431b",
+      "cancellation_dates":[]
+    }
+  ],
+  "current_page": 1,
+  "total_pages": 1
+}

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -98,6 +98,15 @@ module FakeChartmogulApi
     )
   end
 
+  def stub_subscription_listing_api(uuid:, **options)
+    stub_api_response(
+      :get,
+      [subscription_end_point(uuid), resource_params(options)].join("?"),
+      filename: "subscription_list",
+      status: 200
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status: 200, data: nil)
@@ -120,6 +129,10 @@ module FakeChartmogulApi
 
   def transaction_end_point(invoice_uuid)
     ["import", "invoices", invoice_uuid, "transactions"].join("/")
+  end
+
+  def subscription_end_point(customer_uuid)
+    ["import", "customers", customer_uuid, "subscriptions"].join("/")
   end
 
   def api_end_point(end_point)


### PR DESCRIPTION
Retrieve a list of `subscription` objects for a given `customer`. Usages:

```ruby
Chartmogul::Import::Subscription.list(
  uuid: "customer_001", page: 1, per_page: 1
)
```