### PR TITLE
Cancel a customer's subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,16 @@ Chartmogul::Import::Subscription.list(
 )
 ```
 
+#### Cancel Customer's Subscription
+
+Cancel a subscription that was generated from an imported invoice.
+
+```ruby
+Chartmogul::Import::Subscription.cancel(
+  uuid: "subscription_uuid_001", cancelled_at: "2016-01-15 00:00:00"
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/client.rb
+++ b/lib/chartmogul/client.rb
@@ -19,6 +19,10 @@ module Chartmogul
       resources[end_point].post attributes.to_json, content_type: :json
     end
 
+    def patch
+      resources[end_point].patch attributes.to_json, content_type: :json
+    end
+
     def delete
       resources[end_point].delete content_type: :json
     end
@@ -43,6 +47,12 @@ module Chartmogul
   def self.post_resource(end_point, attributes)
     Chartmogul::Response.parse_json(
       Client.new(end_point, attributes).post
+    )
+  end
+
+  def self.patch_resource(end_point, attributes)
+    Chartmogul::Response.parse_json(
+      Client.new(end_point, attributes).patch
     )
   end
 

--- a/lib/chartmogul/import/subscription.rb
+++ b/lib/chartmogul/import/subscription.rb
@@ -8,10 +8,20 @@ module Chartmogul
         super(listing_options)
       end
 
+      def cancel(uuid:, cancelled_at:)
+        Chartmogul.patch_resource(
+          subscription_end_point(uuid), cancelled_at: cancelled_at
+        )
+      end
+
       private
 
       def end_point
         ["customers", customer_uuid, "subscriptions"].join("/")
+      end
+
+      def subscription_end_point(subscription_uuid)
+        ["import", "subscriptions", subscription_uuid].join("/")
       end
     end
   end

--- a/spec/chartmogul/import/subscription_spec.rb
+++ b/spec/chartmogul/import/subscription_spec.rb
@@ -14,4 +14,21 @@ describe Chartmogul::Import::Subscription do
       expect(subscriptions.customer_uuid).to eq(listing_options[:uuid])
     end
   end
+
+  describe ".cancel" do
+    it "cancels the specific subscription" do
+      cancellation_attributes = {
+        uuid: "subscription_uuid_001",
+        cancelled_at: "2016-01-15 00:00:00"
+      }
+
+      stub_subscription_cancellation_api(cancellation_attributes)
+      subscription = Chartmogul::Import::Subscription.cancel(
+        cancellation_attributes
+      )
+
+      expect(subscription.uuid).to eq("subscription_uuid_001")
+      expect(subscription.cancellation_dates.first).to include("2016-01-15")
+    end
+  end
 end

--- a/spec/fixtures/subscription_cancelled.json
+++ b/spec/fixtures/subscription_cancelled.json
@@ -1,0 +1,9 @@
+{
+  "uuid": "subscription_uuid_001",
+  "external_id": "sub_0001",
+  "customer_uuid": "cus_f466e33d-ff2b-4a11-8f85-417eb02157a7",
+  "plan_uuid": "pl_eed05d54-75b4-431b-adb2-eb6b9e543206",
+  "cancellation_dates": ["2016-01-15T00:00:00.000Z"],
+  "data_source_uuid": "ds_fef05d54-47b4-431b-aed2-eb6b9e545430"
+}
+

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -107,6 +107,16 @@ module FakeChartmogulApi
     )
   end
 
+  def stub_subscription_cancellation_api(uuid:, cancelled_at:)
+    stub_api_response(
+      :patch,
+      ["import", "subscriptions", uuid].join("/"),
+      data: { cancelled_at: cancelled_at },
+      filename: "subscription_cancelled",
+      status: 200
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status: 200, data: nil)


### PR DESCRIPTION
Cancels a subscription that was generated from an imported invoice. Usages:

```ruby
Chartmogul::Import::Subscription.cancel(
 uuid: "subscription_uuid_001", cancelled_at: "2016-01-15 00:00:00"
)
```