### PR TITLE
Search customers by their email

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,17 @@ Retrieve a customer object from your ChartMogul account.
 Chartmogul::Enrichment::Customer.find("customer_id")
 ```
 
+#### Search for Customers
+
+Find a list of all `customer` objects with the specified email address in your
+ChartMogul account.
+
+```ruby
+Chartmogul::Enrichment::Customer.search(
+  email: "adam.smith@example.com"
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/enrichment/customer.rb
+++ b/lib/chartmogul/enrichment/customer.rb
@@ -8,10 +8,18 @@ module Chartmogul
         Chartmogul.get_resource(resource_end_point)
       end
 
+      def search(email:)
+        Chartmogul.get_resource(search_end_point, email: email)
+      end
+
       private
 
       def end_point
         customer_id
+      end
+
+      def search_end_point
+        [resource_end_point, "search"].join("/")
       end
 
       def resource_base

--- a/spec/chartmogul/enrichment/customer_spec.rb
+++ b/spec/chartmogul/enrichment/customer_spec.rb
@@ -14,4 +14,20 @@ describe Chartmogul::Enrichment::Customer do
       expect(customer["billing-system-type"]).to eq("Stripe")
     end
   end
+
+  describe ".search" do
+    it "retrieves the list of customers" do
+      customer_email = "adam@smith.com"
+
+      stub_customer_search_api(email: customer_email)
+      results = Chartmogul::Enrichment::Customer.search(
+        email: customer_email
+      )
+
+      expect(results.page).to eq(1)
+      expect(results.entries.count).to eq(1)
+      expect(results.entries.first.name).to eq("Adam Smith")
+      expect(results.entries.first.email).to eq(customer_email)
+    end
+  end
 end

--- a/spec/fixtures/search_results.json
+++ b/spec/fixtures/search_results.json
@@ -1,0 +1,65 @@
+{
+  "entries":[
+    {
+      "id": 25647,
+      "uuid": "cus_de305d54-75b4-431b",
+      "external_id": "34916129",
+      "email": "adam@smith.com",
+      "name": "Adam Smith",
+      "address": {
+        "address_line1": "First line of address",
+        "address_line2": "Second line of address",
+        "address_zip": "0185128",
+        "city": "Nowhereville",
+        "country": "US",
+        "state": "Alaska"
+      },
+      "mrr": 3000,
+      "arr": 36000,
+      "status": "Active",
+      "customer-since": "2015-06-09T13:16:00-04:00",
+      "billing-system-url": "https:\/\/dashboard.stripe.com\/customers\/cus_4Z2ZpyJFuQ0XMb",
+      "chartmogul-url": "https:\/\/app.chartmogul.com\/#customers\/25647-Example_Company",
+      "billing-system-type": "Stripe",
+      "currency": "USD",
+      "currency-sign": "$",
+      "attributes": {
+        "custom": {
+          "CAC": 213,
+          "utmCampaign": "social media 1",
+          "convertedAt": "2015-09-08 00:00:00",
+          "pro": false,
+          "salesRep": "Gabi"
+        },
+        "tags": ["engage", "unit loss", "discountable"],
+        "stripe": {
+          "uid": 7,
+          "coupon": true
+        }, 
+        "clearbit": {
+          "id": "027b0d40-016c-40ea-8925-a076fa640992",
+          "name": "Acme",
+          "legalName": "Acme Inc.",
+          "domain": "acme.com",
+          "url": "http://acme.com",
+          "metrics": {
+            "raised": 1502450000,
+            "employees": 1000,
+            "googleRank": 7,
+            "alexaGlobalRank": 2319,
+            "marketCap": null
+          },
+          "category": {
+            "sector": "Information Technology",
+            "industryGroup": "Software and Services",
+            "industry": "Software",
+            "subIndustry": "Application Software"
+          }
+        }
+      }
+    }
+  ],
+  "has_more":false,
+  "per_page":200,
+  "page":1
+}

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -122,6 +122,15 @@ module FakeChartmogulApi
     )
   end
 
+  def stub_customer_search_api(options)
+    stub_api_response(
+      :get,
+      [search_end_point, resource_params(options)].join("?"),
+      filename: "search_results",
+      status: 200
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status: 200, data: nil)
@@ -148,6 +157,10 @@ module FakeChartmogulApi
 
   def subscription_end_point(customer_uuid)
     ["import", "customers", customer_uuid, "subscriptions"].join("/")
+  end
+
+  def search_end_point
+    "customers/search"
   end
 
   def api_end_point(end_point)


### PR DESCRIPTION
Find a list of all customer objects with the specified email address in your ChartMogul account. Usages:

```ruby
Chartmogul::Enrichment::Customer.search(
  email: "adam@smith.com"
)
```