### PR TITLE
Listing all existing customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,16 @@ Chartmogul::Enrichment::Customer.search(
 )
 ```
 
+#### List all Customers
+
+Retrieve a list of all customer objects in your ChartMogul account.
+
+```ruby
+Chartmogul::Enrichment::Customer.list(
+  page: 1, per_page: 10
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/base.rb
+++ b/lib/chartmogul/base.rb
@@ -1,5 +1,9 @@
 module Chartmogul
   class Base
+    def list(options = {})
+      Chartmogul.get_resource(resource_end_point, options)
+    end
+
     def self.method_missing(method_name, *arguments, &block)
       resource = new
       if resource.respond_to?(method_name, include_private: false)

--- a/lib/chartmogul/import/base.rb
+++ b/lib/chartmogul/import/base.rb
@@ -1,10 +1,6 @@
 module Chartmogul
   module Import
     class Base < Chartmogul::Base
-      def list(options = {})
-        Chartmogul.get_resource(resource_end_point, options)
-      end
-
       def create(attributes)
         if required_keys_exist?(attributes)
           Chartmogul.post_resource(resource_end_point, attributes)

--- a/spec/chartmogul/enrichment/customer_spec.rb
+++ b/spec/chartmogul/enrichment/customer_spec.rb
@@ -30,4 +30,18 @@ describe Chartmogul::Enrichment::Customer do
       expect(results.entries.first.email).to eq(customer_email)
     end
   end
+
+  describe ".list" do
+    it "list all customers" do
+      listing_options = { page: 1, per_page: 1 }
+
+      stub_enrichment_customer_list_api(listing_options)
+      customers = Chartmogul::Enrichment::Customer.list(listing_options)
+
+      expect(customers.page).to eq(1)
+      expect(customers.per_page).to eq(1)
+      expect(customers.entries.count).to eq(1)
+      expect(customers.entries.first.name).to eq("Adam Smith")
+    end
+  end
 end

--- a/spec/fixtures/customer_entries.json
+++ b/spec/fixtures/customer_entries.json
@@ -60,6 +60,6 @@
     }
   ],
   "has_more":false,
-  "per_page":200,
+  "per_page":1,
   "page":1
 }

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -126,7 +126,16 @@ module FakeChartmogulApi
     stub_api_response(
       :get,
       [search_end_point, resource_params(options)].join("?"),
-      filename: "search_results",
+      filename: "customer_entries",
+      status: 200
+    )
+  end
+
+  def stub_enrichment_customer_list_api(options)
+    stub_api_response(
+      :get,
+      ["customers", resource_params(options)].join("?"),
+      filename: "customer_entries",
       status: 200
     )
   end


### PR DESCRIPTION
Retrieve a list of all customer objects in your ChartMogul account. Usages:

```ruby
Chartmogul::Enrichment::Customer.list(
  page: 1, per_page: 1
)
```