### PR TITLE
Add new tag using customer email

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,21 @@ Chartmogul::Enrichment::Tag.create(
 )
 ```
 
+#### Add Tags to Customers with email
+
+Adds tags to customers that have the specified email address.
+
+```ruby
+# Add a single tag for a specified customer
+#
+# If you want to add multiple tag in one request, simply
+# pass an Array as `tag: ["tag_one", "tag_two", "tag_three"]`
+
+Chartmogul::Enrichment::Tag.create(
+  email: "customer@example.com", tag: "important"
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/enrichment/tag.rb
+++ b/lib/chartmogul/enrichment/tag.rb
@@ -3,15 +3,25 @@ module Chartmogul
     class Tag < Base
       attr_reader :customer_id
 
-      def create(customer_id:, tag:)
+      def create(tag:, customer_id: nil, email: nil)
         @customer_id = customer_id
-        create_api(tags: build_array(tag))
+        create_api(build_tag_attributes(tag, email))
       end
 
       private
 
       def end_point
-        [customer_id, "attributes", "tags"]
+        [customer_id, "attributes", "tags"].compact.join("/")
+      end
+
+      def build_tag_attributes(tag, email)
+        Hash.new.tap do |attributes|
+          attributes[:tags] = build_array(tag)
+
+          unless email.nil?
+            attributes[:email] = email
+          end
+        end
       end
     end
   end

--- a/spec/chartmogul/enrichment/tag_spec.rb
+++ b/spec/chartmogul/enrichment/tag_spec.rb
@@ -2,18 +2,32 @@ require "spec_helper"
 
 describe Chartmogul::Enrichment::Tag do
   describe ".create" do
-    it "adds a new tag to the customer" do
-      tag_attributes = {
-        customer_id: "customer_id_001", tag: "important"
-      }
+    context "when customer id and tags provided" do
+      it "adds a new tag to the customer" do
+        tag_attributes = {
+          customer_id: "customer_id_001", tag: "important"
+        }
 
-      stub_customer_tag_create_api(tag_attributes)
-      tags = Chartmogul::Enrichment::Tag.create(
-        tag_attributes
-      )
+        stub_customer_tag_create_api(tag_attributes)
+        tags = Chartmogul::Enrichment::Tag.create(
+          tag_attributes
+        )
 
-      expect(tags.tags.count).to eq(5)
-      expect(tags.tags).to include("important")
+        expect(tags.tags.count).to eq(5)
+        expect(tags.tags).to include("important")
+      end
+    end
+
+    context "when email and tag provided" do
+      it "adds a new tag to the customer" do
+        tag_attributes = { email: "cusotmer@example.com", tag: "important" }
+
+        stub_tag_create_api_with_email(tag_attributes)
+        tags = Chartmogul::Enrichment::Tag.create(tag_attributes)
+
+        expect(tags.tags.count).to eq(5)
+        expect(tags.tags).to include("important")
+      end
     end
   end
 end

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -159,6 +159,16 @@ module FakeChartmogulApi
     )
   end
 
+  def stub_tag_create_api_with_email(email:, tag:)
+    stub_api_response(
+      :post,
+      "customers/attributes/tags",
+      data: { tags: [tag], email: email },
+      filename: "tag_created",
+      status: 200
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status: 200, data: nil)


### PR DESCRIPTION
Adds tags to customers that have the specified email address. Usages:

```ruby
Chartmogul::Enrichment::Tag.create(
  email: "customer@example.com", tag: "important"
)
```