### PR TITLE
Remove tags from a customer

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,21 @@ Chartmogul::Enrichment::Tag.create(
 )
 ```
 
+#### Remove Tags from a Customer
+
+Removes tags from a given customer.
+
+```ruby
+# Remove a single tag for a specified customer
+#
+# If you want to remove multiple tag in one request, simply
+# pass an Array as `tag: ["tag_one", "tag_two", "tag_three"]`
+
+Chartmogul::Enrichment::Tag.delete(
+  customer_id: customer_id, tag: "important"
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/client.rb
+++ b/lib/chartmogul/client.rb
@@ -51,7 +51,7 @@ module Chartmogul
     Client.new(end_point, :patch, attributes).execute
   end
 
-  def self.delete_resource(end_point)
-    Client.new(end_point, :delete).execute
+  def self.delete_resource(end_point, attributes = {})
+    Client.new(end_point, :delete, attributes).execute
   end
 end

--- a/lib/chartmogul/enrichment/tag.rb
+++ b/lib/chartmogul/enrichment/tag.rb
@@ -8,6 +8,14 @@ module Chartmogul
         create_api(build_tag_attributes(tag, email))
       end
 
+      def delete(customer_id:, tag:)
+        @customer_id = customer_id
+
+        Chartmogul.delete_resource(
+          resource_end_point, tags: build_array(tag)
+        )
+      end
+
       private
 
       def end_point

--- a/spec/chartmogul/enrichment/tag_spec.rb
+++ b/spec/chartmogul/enrichment/tag_spec.rb
@@ -30,4 +30,16 @@ describe Chartmogul::Enrichment::Tag do
       end
     end
   end
+
+  describe ".remove" do
+    it "removes the specified tag from customer" do
+      tag_attributes = { customer_id: "customer_id_001", tag: "important" }
+
+      stub_customer_tag_delete_api(tag_attributes)
+      tags = Chartmogul::Enrichment::Tag.delete(tag_attributes)
+
+      expect(tags.tags.count).to eq(4)
+      expect(tags.tags).not_to include("important")
+    end
+  end
 end

--- a/spec/fixtures/tag_deleted.json
+++ b/spec/fixtures/tag_deleted.json
@@ -1,0 +1,3 @@
+{
+  "tags": ["engage", "unit loss", "discountable", "Prio1"]
+}

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -169,6 +169,16 @@ module FakeChartmogulApi
     )
   end
 
+  def stub_customer_tag_delete_api(customer_id:, tag:)
+    stub_api_response(
+      :delete,
+      ["customers", customer_id, "attributes", "tags"].join("/"),
+      data: { tags: [tag] },
+      filename: "tag_deleted",
+      status: 200
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status: 200, data: nil)


### PR DESCRIPTION
Removes tags from a given customer. Usages:

```ruby
Chartmogul::Enrichment::Tag.delete(
  customer_id: "customer_id", tag: "important"
)
```