### PR TITLE
Add custom attribute to customer

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,32 @@ Chartmogul::Enrichment::Tag.delete(
 )
 ```
 
+### Custom Attributes
+
+Custom Attributes are a type of customer attribute. They are key-value
+metadata that can be used to describe properties of customers. Custom
+Attributes are useful for storing structured information on a `customer`.
+
+#### Add Custom Attributes
+
+Adds custom attributes to a given customer.
+
+```ruby
+# Add a single custom attribute for a specified customer
+#
+# If you want to add multiple custom attribute, simply pass in
+# an Array as `attribute: [attribute_hash, another_attribute_hash]`
+
+Chartmogul::Enrichment::CustomAttribute.create(
+  customer_id: customer_id,
+  attribute: {
+    type: "String",
+    key: "Channel",
+    value: "Facebook"
+  }
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/enrichment.rb
+++ b/lib/chartmogul/enrichment.rb
@@ -2,6 +2,7 @@ require "chartmogul/enrichment/base"
 require "chartmogul/enrichment/tag"
 require "chartmogul/enrichment/customer"
 require "chartmogul/enrichment/attribute"
+require "chartmogul/enrichment/custom_attribute"
 
 module Chartmogul
   module Enrichment

--- a/lib/chartmogul/enrichment/custom_attribute.rb
+++ b/lib/chartmogul/enrichment/custom_attribute.rb
@@ -1,0 +1,27 @@
+module Chartmogul
+  module Enrichment
+    class CustomAttribute < Base
+      attr_reader :customer_id
+
+      def create(customer_id:, attribute:)
+        @customer_id = customer_id
+        create_api(custom: build_array(attribute))
+      end
+
+      private
+
+      def end_point
+        [customer_id, "attributes", "custom"].compact.join("/")
+      end
+
+      def required_keys
+        [:type, :key, :value]
+      end
+
+      def required_keys_exist?(attributes)
+        attributes = attributes[:custom]
+        !attributes.map { |attribute| super(attribute) }.include?(false)
+      end
+    end
+  end
+end

--- a/spec/chartmogul/enrichment/custom_attribute_spec.rb
+++ b/spec/chartmogul/enrichment/custom_attribute_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe Chartmogul::Enrichment::CustomAttribute do
+  describe ".create" do
+    it "adds a custom attribute to the customer" do
+      customer_id = "customer_id_001"
+      attribute = {
+        type: "String",
+        key: "channel",
+        value: "Facebook"
+      }
+
+      stub_custom_attribute_create_api(
+        customer_id: customer_id, attribute: attribute
+      )
+
+      custom_attribute = Chartmogul::Enrichment::CustomAttribute.create(
+        customer_id: customer_id, attribute: attribute
+      )
+
+      expect(custom_attribute.custom["CAC"]).not_to be_nil
+      expect(custom_attribute.custom.channel).to eq("Facebook")
+    end
+  end
+end

--- a/spec/fixtures/custom_attribute_created.json
+++ b/spec/fixtures/custom_attribute_created.json
@@ -1,0 +1,9 @@
+{
+  "custom": {
+    "CAC": 213,
+    "utmCampaign": "social media 1",
+    "convertedAt": "2015-09-08 00:00:00",
+    "channel": "Facebook",
+    "age": 8
+  }
+}

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -179,6 +179,16 @@ module FakeChartmogulApi
     )
   end
 
+  def stub_custom_attribute_create_api(customer_id:, attribute:)
+    stub_api_response(
+      :post,
+      ["customers", customer_id, "attributes", "custom"].join("/"),
+      data: { custom: [attribute] },
+      filename: "custom_attribute_created",
+      status: 200
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status: 200, data: nil)


### PR DESCRIPTION
Adds custom attributes to a given customer. Usages:

```ruby
Chartmogul::Enrichment::CustomAttribute.create(
  customer_id: customer_id,
  attribute: { type: "string", key: "channel", value: "Facebook" }
)
```