### PR TITLE
Add custom attribute with customer email

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,26 @@ Chartmogul::Enrichment::CustomAttribute.create(
 )
 ```
 
+#### Add Custom Attributes with Email
+
+Adds custom attributes to customers that have the specified email address.
+
+```ruby
+# Add a single custom attribute for a specified customer
+#
+# If you want to add multiple custom attribute, simply pass in
+# an Array as `attribute: [attribute_hash, another_attribute_hash]`
+
+Chartmogul::Enrichment::CustomAttribute.create(
+  email: "customer@example.com",
+  attribute: {
+    type: "String",
+    key: "Channel",
+    value: "Facebook"
+  }
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/enrichment/custom_attribute.rb
+++ b/lib/chartmogul/enrichment/custom_attribute.rb
@@ -3,9 +3,9 @@ module Chartmogul
     class CustomAttribute < Base
       attr_reader :customer_id
 
-      def create(customer_id:, attribute:)
+      def create(attribute:, customer_id: nil, email: nil)
         @customer_id = customer_id
-        create_api(custom: build_array(attribute))
+        create_api(build_custom_attributes(attribute, email))
       end
 
       private
@@ -21,6 +21,16 @@ module Chartmogul
       def required_keys_exist?(attributes)
         attributes = attributes[:custom]
         !attributes.map { |attribute| super(attribute) }.include?(false)
+      end
+
+      def build_custom_attributes(attribute, email)
+        Hash.new.tap do |attributes|
+          attributes[:custom] = build_array(attribute)
+
+          unless email.nil?
+            attributes[:email] = email
+          end
+        end
       end
     end
   end

--- a/spec/chartmogul/enrichment/custom_attribute_spec.rb
+++ b/spec/chartmogul/enrichment/custom_attribute_spec.rb
@@ -2,24 +2,48 @@ require "spec_helper"
 
 describe Chartmogul::Enrichment::CustomAttribute do
   describe ".create" do
-    it "adds a custom attribute to the customer" do
-      customer_id = "customer_id_001"
-      attribute = {
-        type: "String",
-        key: "channel",
-        value: "Facebook"
-      }
+    context "when customer id and attribute provided" do
+      it "adds a custom attribute to the customer" do
+        customer_id = "customer_id_001"
+        attribute = {
+          type: "String",
+          key: "channel",
+          value: "Facebook"
+        }
 
-      stub_custom_attribute_create_api(
-        customer_id: customer_id, attribute: attribute
-      )
+        stub_custom_attribute_create_api(
+          customer_id: customer_id, attribute: attribute
+        )
 
-      custom_attribute = Chartmogul::Enrichment::CustomAttribute.create(
-        customer_id: customer_id, attribute: attribute
-      )
+        custom_attribute = Chartmogul::Enrichment::CustomAttribute.create(
+          customer_id: customer_id, attribute: attribute
+        )
 
-      expect(custom_attribute.custom["CAC"]).not_to be_nil
-      expect(custom_attribute.custom.channel).to eq("Facebook")
+        expect(custom_attribute.custom["CAC"]).not_to be_nil
+        expect(custom_attribute.custom.channel).to eq("Facebook")
+      end
+    end
+
+    describe "when email and custom attribute provided" do
+      it "adds a custom attribute to the customer" do
+        email = "customer@example.com"
+        attribute = {
+          type: "String",
+          key: "channel",
+          value: "Facebook"
+        }
+
+        stub_custom_attribute_create_api_with_email(
+          email: email, attribute: attribute
+        )
+
+        custom_attribute = Chartmogul::Enrichment::CustomAttribute.create(
+          email: email, attribute: attribute
+        )
+
+        expect(custom_attribute.custom["CAC"]).not_to be_nil
+        expect(custom_attribute.custom.channel).to eq("Facebook")
+      end
     end
   end
 end

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -189,6 +189,16 @@ module FakeChartmogulApi
     )
   end
 
+  def stub_custom_attribute_create_api_with_email(email:, attribute:)
+    stub_api_response(
+      :post,
+      "customers/attributes/custom",
+      data: { custom: [attribute], email: email },
+      filename: "custom_attribute_created",
+      status: 200
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status: 200, data: nil)


### PR DESCRIPTION
Adds custom attributes to customers that have the specified email address. Usages:

```ruby
Chartmogul::Enrichment::CustomAttribute.create(
  email: customer_email,
  attribute: {
    type: "String",
    key: "channel",
    value: "Facebook"
  }
)
```