### PR TITLE
Remove Custom Attributes from a Customer

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,21 @@ Chartmogul::Enrichment::CustomAttribute.update(
 )
 ```
 
+#### Remove Custom Attributes
+
+Removes custom attributes from a given customer.
+
+```ruby
+# Remove a single custom attribute form a given customer
+#
+# If you want to remove multiple custom attributes, simply pass in an
+# Array as `attribute: ["attribute_key", "another_attribute_key"]`
+
+Chartmogul::Enrichment::CustomAttribute.delete(
+  customer_id: customer_id, attribute: "attribute_key"
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/base.rb
+++ b/lib/chartmogul/base.rb
@@ -21,6 +21,10 @@ module Chartmogul
       end
     end
 
+    def delete_api(attributes = {})
+      Chartmogul.delete_resource(resource_end_point, attributes)
+    end
+
     def resource_end_point
       [resource_base, end_point].compact.join("/")
     end

--- a/lib/chartmogul/enrichment/custom_attribute.rb
+++ b/lib/chartmogul/enrichment/custom_attribute.rb
@@ -13,6 +13,11 @@ module Chartmogul
         Chartmogul.put_resource(resource_end_point, custom: attribute)
       end
 
+      def delete(customer_id:, attribute:)
+        @customer_id = customer_id
+        delete_api(custom: build_array(attribute))
+      end
+
       private
 
       def end_point

--- a/lib/chartmogul/enrichment/tag.rb
+++ b/lib/chartmogul/enrichment/tag.rb
@@ -10,10 +10,7 @@ module Chartmogul
 
       def delete(customer_id:, tag:)
         @customer_id = customer_id
-
-        Chartmogul.delete_resource(
-          resource_end_point, tags: build_array(tag)
-        )
+        delete_api(tags: build_array(tag))
       end
 
       private

--- a/spec/chartmogul/enrichment/custom_attribute_spec.rb
+++ b/spec/chartmogul/enrichment/custom_attribute_spec.rb
@@ -51,6 +51,21 @@ describe Chartmogul::Enrichment::CustomAttribute do
     end
   end
 
+  describe ".delete" do
+    it "removes custom attributes from the customer" do
+      custom_attrubute_hash = {
+        customer_id: "customer_id_001", attribute: "channel"
+      }
+
+      stub_custom_attribute_delete_api(custom_attrubute_hash)
+      custom_attribute = Chartmogul::Enrichment::CustomAttribute.delete(
+        custom_attrubute_hash
+      )
+
+      expect(custom_attribute.custom.channel).to be_nil
+    end
+  end
+
   def attribute
     {
       type: "String",

--- a/spec/fixtures/custom_attribute_deleted.json
+++ b/spec/fixtures/custom_attribute_deleted.json
@@ -1,0 +1,8 @@
+{
+  "custom": {
+    "CAC": 213,
+    "utmCampaign": "social media 1",
+    "convertedAt": "2015-09-08 00:00:00",
+    "pro": false
+  }
+}

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -209,6 +209,16 @@ module FakeChartmogulApi
     )
   end
 
+  def stub_custom_attribute_delete_api(customer_id:, attribute:)
+    stub_api_response(
+      :delete,
+      ["customers", customer_id, "attributes", "custom"].join("/"),
+      data: { custom: [attribute] },
+      filename: "custom_attribute_deleted",
+      status: 200
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status: 200, data: nil)


### PR DESCRIPTION
Removes custom attributes from a given customer. Usages:

```ruby
Chartmogul::Enrichment::CustomAttribute.delete(
  customer_id: customer_id, custom: "channel"
)
```