### PR TITLE
Retrieving all key metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,25 @@ Chartmogul::Enrichment::CustomAttribute.delete(
 )
 ```
 
+### Metrics API
+
+The Metrics API allows users to programmatically pull the subscription metrics
+that ChartMogul generates.
+
+#### Retrieve all key metrics
+
+Retrieve all key metrics, for the specified time period.
+
+```ruby
+Chartmogul::Metric.key_metrics(
+  start_date: "2015-05-12",
+  end_date: "2015-05-12",
+  interval: "month",
+  geo: "US,GB,DE",
+  plans: "Bronze Plan"
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -2,6 +2,7 @@ require "chartmogul/version"
 require "chartmogul/client"
 require "chartmogul/base"
 require "chartmogul/import"
+require "chartmogul/metric"
 require "chartmogul/enrichment"
 
 module Chartmogul

--- a/lib/chartmogul/metric.rb
+++ b/lib/chartmogul/metric.rb
@@ -1,0 +1,7 @@
+require "chartmogul/metrics/base"
+require "chartmogul/metrics/key_metric"
+
+module Chartmogul
+  module Metric
+  end
+end

--- a/lib/chartmogul/metrics/base.rb
+++ b/lib/chartmogul/metrics/base.rb
@@ -1,0 +1,11 @@
+module Chartmogul
+  module Metric
+    class Base < Chartmogul::Base
+      private
+
+      def resource_base
+        "metrics"
+      end
+    end
+  end
+end

--- a/lib/chartmogul/metrics/key_metric.rb
+++ b/lib/chartmogul/metrics/key_metric.rb
@@ -1,0 +1,31 @@
+module Chartmogul
+  module Metric
+    class KeyMetric < Base
+      def list(options)
+        list_resource(stringify_keys(options))
+      end
+
+      private
+
+      def end_point
+        "all"
+      end
+
+      def stringify_keys(options)
+        Hash.new.tap do |attribute|
+          options.each { |key, value| attribute[dasherize(key)] = value }
+        end
+      end
+
+      def dasherize(underscored_word)
+        underscored_word.to_s.tr("_".freeze, "-".freeze)
+      end
+    end
+
+    def self.key_metrics(start_date:, end_date:, **options)
+      KeyMetric.list(
+        start_date: start_date, end_date: end_date, **options
+      )
+    end
+  end
+end

--- a/spec/chartmogul/metrics/key_matric_spec.rb
+++ b/spec/chartmogul/metrics/key_matric_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe Chartmogul::Metric do
+  describe ".key_metrics" do
+    it "retrieve all key matrics" do
+      metric_attributes = {
+        start_date: "2015-05-12",
+        end_date: "2015-05-12",
+        interval: "month",
+        geo: "US,GB,DE",
+        plans: "Bronze Plan"
+      }
+
+      stub_listing_key_metrics_api(metric_attributes)
+      metrics = Chartmogul::Metric.key_metrics(metric_attributes)
+
+      expect(metrics.entries.first.asp).not_to be_nil
+      expect(metrics.entries.first.arpa).not_to be_nil
+      expect(metrics.entries.first.customers).to eq(331)
+      expect(metrics.entries.first["customer-churn-rate"]).not_to be_nil
+    end
+  end
+end

--- a/spec/fixtures/key_metrics.json
+++ b/spec/fixtures/key_metrics.json
@@ -1,0 +1,26 @@
+{
+  "entries":[
+    {
+      "date":"2015-01-31",
+      "customer-churn-rate":20,
+      "mrr-churn-rate":14,
+      "ltv":1250.3,
+      "customers":331,
+      "asp":125,
+      "arpa":1250,
+      "arr":254000,
+      "mrr":21166
+    },
+    {
+      "date":"2015-02-28",
+      "customer-churn-rate":20,
+      "mrr-churn-rate":22,
+      "ltv":1248,
+      "customers":329,
+      "asp":125,
+      "arpa":1250,
+      "arr":238000,
+      "mrr":21089
+    }
+  ]
+}

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -219,6 +219,15 @@ module FakeChartmogulApi
     )
   end
 
+  def stub_listing_key_metrics_api(attributes)
+    stub_api_response(
+      :get,
+      ["metrics/all", metrics_params(attributes)].join("?"),
+      filename: "key_metrics",
+      status: 200
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status: 200, data: nil)
@@ -229,6 +238,10 @@ module FakeChartmogulApi
 
   def resource_params(options)
     options.map { |key, value| [key, value].join("=") }.join("&")
+  end
+
+  def metrics_params(options)
+    resource_params(stringify_keys(options))
   end
 
   def plan_end_point
@@ -278,5 +291,15 @@ module FakeChartmogulApi
 
   def fixture_file(filename)
     File.read "./spec/fixtures/#{filename}.json"
+  end
+
+  def stringify_keys(options)
+    Hash.new.tap do |attribute|
+      options.each { |key, value| attribute[dasherize(key)] = value }
+    end
+  end
+
+  def dasherize(underscored_word)
+    underscored_word.to_s.tr("_".freeze, "-".freeze)
   end
 end


### PR DESCRIPTION
Retrieve all key metrics, for the specified time period. Usages

```ruby
Chartmogul::Metric.key_metrics(
  start_date: "2015-05-12",
  end_date: "2015-05-12",
  interval: "month",
  geo: "US,GB,DE",
  plans: "Bronze Plan"
)
```