### PR TITLE
Retrieve specified ARR metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,20 @@ Chartmogul::Metric.mrr_metrics(
 )
 ```
 
+#### Retrieve ARR
+
+Retrieve the Annualized Run Rate (ARR), for the specified time period.
+
+```ruby
+Chartmogul::Metric.arr_metrics(
+  start_date: "2015-05-12",
+  end_date: "2015-05-12",
+  interval: "month",
+  geo: "US,GB,DE",
+  plans: "Bronze Plan"
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/metric.rb
+++ b/lib/chartmogul/metric.rb
@@ -1,6 +1,7 @@
 require "chartmogul/metrics/base"
 require "chartmogul/metrics/key_metric"
 require "chartmogul/metrics/mrr_metric"
+require "chartmogul/metrics/arr_metric"
 
 module Chartmogul
   module Metric

--- a/lib/chartmogul/metrics/arr_metric.rb
+++ b/lib/chartmogul/metrics/arr_metric.rb
@@ -1,0 +1,17 @@
+module Chartmogul
+  module Metric
+    class ARRMetric < Base
+      private
+
+      def end_point
+        "arr"
+      end
+    end
+
+    def self.arr_metrics(start_date:, end_date:, **options)
+      ARRMetric.retrieve(
+        start_date: start_date, end_date: end_date, **options
+      )
+    end
+  end
+end

--- a/spec/chartmogul/metric_spec.rb
+++ b/spec/chartmogul/metric_spec.rb
@@ -23,6 +23,17 @@ describe Chartmogul::Metric do
     end
   end
 
+  describe ".arr_metrics" do
+    it "retrieves the annualized run rate" do
+      stub_listing_arr_metrics_api(metric_attributes)
+      metrics = Chartmogul::Metric.arr_metrics(metric_attributes)
+
+      expect(metrics.summary.current).not_to be_nil
+      expect(metrics.entries.first.arr).not_to be_nil
+      expect(metrics.entries.first.date).not_to be_nil
+    end
+  end
+
   def metric_attributes
     @metric_attributes ||= {
       start_date: "2015-05-12",

--- a/spec/fixtures/arr_metrics.json
+++ b/spec/fixtures/arr_metrics.json
@@ -1,0 +1,17 @@
+{
+  "entries":[
+    {
+      "date":"2015-01-31",
+      "arr":360000
+    },
+    {
+      "date":"2015-02-28",
+      "arr":36600000
+    }
+  ],
+  "summary":{
+    "current":305520000,
+    "previous":305520000,
+    "percentage-change":0.0
+  }
+}

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -227,6 +227,10 @@ module FakeChartmogulApi
     stub_retrive_metrics_api("mrr", attributes, "mrr_metrics")
   end
 
+  def stub_listing_arr_metrics_api(attributes)
+    stub_retrive_metrics_api("arr", attributes, "arr_metrics")
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status: 200, data: nil)


### PR DESCRIPTION
Retrieves the Annualized Run Rate (ARR), for the specified time period. Usages:

```ruby
Chartmogul::Metric.arr_metrics(
  start_date: "2015-05-12",
  end_date: "2015-05-12",
  interval: "month",
  geo: "US,GB,DE",
  plans: "Bronze Plan"
)
```