### PR TITLE
Retrieve specified ARPA metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,20 @@ Chartmogul::Metric.arr_metrics(
 )
 ```
 
+#### Retrieve ARPA
+
+Retrieve the Average Revenue Per Account (ARPA), for the specified time period
+
+```ruby
+Chartmogul::Metric.arpa_metrics(
+  start_date: "2015-05-12",
+  end_date: "2015-05-12",
+  interval: "month",
+  geo: "US,GB,DE",
+  plans: "Bronze Plan"
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/metric.rb
+++ b/lib/chartmogul/metric.rb
@@ -2,6 +2,7 @@ require "chartmogul/metrics/base"
 require "chartmogul/metrics/key_metric"
 require "chartmogul/metrics/mrr_metric"
 require "chartmogul/metrics/arr_metric"
+require "chartmogul/metrics/arpa_metric"
 
 module Chartmogul
   module Metric

--- a/lib/chartmogul/metrics/arpa_metric.rb
+++ b/lib/chartmogul/metrics/arpa_metric.rb
@@ -1,0 +1,17 @@
+module Chartmogul
+  module Metric
+    class ARPAMetric < Base
+      private
+
+      def end_point
+        "arpa"
+      end
+    end
+
+    def self.arpa_metrics(start_date:, end_date:, **options)
+      ARPAMetric.retrieve(
+        start_date: start_date, end_date: end_date, **options
+      )
+    end
+  end
+end

--- a/spec/chartmogul/metric_spec.rb
+++ b/spec/chartmogul/metric_spec.rb
@@ -13,7 +13,7 @@ describe Chartmogul::Metric do
   end
 
   describe ".mrr_metrics" do
-    it "retrieves the monthly recurring revenue" do
+    it "retrieves the monthly recurring revenue metrics" do
       stub_listing_mrr_metrics_api(metric_attributes)
       metrics = Chartmogul::Metric.mrr_metrics(metric_attributes)
 
@@ -24,12 +24,23 @@ describe Chartmogul::Metric do
   end
 
   describe ".arr_metrics" do
-    it "retrieves the annualized run rate" do
+    it "retrieves the annualized run rate metrics" do
       stub_listing_arr_metrics_api(metric_attributes)
       metrics = Chartmogul::Metric.arr_metrics(metric_attributes)
 
       expect(metrics.summary.current).not_to be_nil
       expect(metrics.entries.first.arr).not_to be_nil
+      expect(metrics.entries.first.date).not_to be_nil
+    end
+  end
+
+  describe ".arpa_metrics" do
+    it "retrieves the average revenue per account metrics" do
+      stub_listing_arpa_metrics_api(metric_attributes)
+      metrics = Chartmogul::Metric.arpa_metrics(metric_attributes)
+
+      expect(metrics.summary.current).not_to be_nil
+      expect(metrics.entries.first.arpa).not_to be_nil
       expect(metrics.entries.first.date).not_to be_nil
     end
   end

--- a/spec/fixtures/arpa_metrics.json
+++ b/spec/fixtures/arpa_metrics.json
@@ -1,0 +1,17 @@
+{
+  "entries":[
+    {
+      "date":"2015-01-03",
+      "arpa":15000
+    },
+    {
+      "date":"2015-01-10",
+      "arpa":15000
+    }
+  ],
+  "summary":{
+    "current":980568,
+    "previous":980568,
+    "percentage-change":0.0
+  }
+}

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -231,6 +231,10 @@ module FakeChartmogulApi
     stub_retrive_metrics_api("arr", attributes, "arr_metrics")
   end
 
+  def stub_listing_arpa_metrics_api(attributes)
+    stub_retrive_metrics_api("arpa", attributes, "arpa_metrics")
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status: 200, data: nil)


### PR DESCRIPTION
Retrieve the Average Revenue Per Account (ARPA), for the specified time period. Usages:

```ruby
Chartmogul::Metric.arpa_metrics(
  start_date: "2015-05-12",
  end_date: "2015-05-12",
  interval: "month",
  geo: "US,GB,DE",
  plans: "Bronze Plan"
)
```