### PR TITLE
Retrieve customer count metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,20 @@ Chartmogul::Metric.asp_metrics(
 )
 ```
 
+#### Retrieve Customer Count
+
+Retrieve the number of active customers, for the specified time period.
+
+```ruby
+Chartmogul::Metric.cc_metrics(
+  start_date: "2015-05-12",
+  end_date: "2015-05-12",
+  interval: "month",
+  geo: "US,GB,DE",
+  plans: "Bronze Plan"
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/metric.rb
+++ b/lib/chartmogul/metric.rb
@@ -4,6 +4,7 @@ require "chartmogul/metrics/mrr_metric"
 require "chartmogul/metrics/arr_metric"
 require "chartmogul/metrics/asp_metric"
 require "chartmogul/metrics/arpa_metric"
+require "chartmogul/metrics/customer_count"
 
 module Chartmogul
   module Metric

--- a/lib/chartmogul/metrics/customer_count.rb
+++ b/lib/chartmogul/metrics/customer_count.rb
@@ -1,0 +1,17 @@
+module Chartmogul
+  module Metric
+    class CustomerCount < Base
+      private
+
+      def end_point
+        "customer-count"
+      end
+    end
+
+    def self.cc_metrics(start_date:, end_date:, **options)
+      CustomerCount.retrieve(
+        start_date: start_date, end_date: end_date, **options
+      )
+    end
+  end
+end

--- a/spec/chartmogul/metric_spec.rb
+++ b/spec/chartmogul/metric_spec.rb
@@ -56,6 +56,16 @@ describe Chartmogul::Metric do
     end
   end
 
+  describe ".cc_metrics" do
+    it "retrieves the number of active customers metrics" do
+      stub_retrieving_metrics_api("customer-count", metric_attributes)
+      metrics = Chartmogul::Metric.cc_metrics(metric_attributes)
+
+      expect(metrics.summary.current).not_to be_nil
+      expect(metrics.entries.first.customers).not_to be_nil
+    end
+  end
+
   def metric_attributes
     @metric_attributes ||= {
       start_date: "2015-05-12",

--- a/spec/fixtures/customer-count_metrics.json
+++ b/spec/fixtures/customer-count_metrics.json
@@ -1,0 +1,13 @@
+{
+  "entries":[
+    {
+      "date":"2015-07-31",
+      "customers":382
+    }
+  ],
+  "summary":{
+    "current":382,
+    "previous":379,
+    "percentage-change":0.8
+  }
+}


### PR DESCRIPTION
Retrieve the number of active customers, for the specified time period. Usages:

```ruby
Chartmogul::Metric.cc_metrics(
  start_date: "2015-05-12",
  end_date: "2015-05-12",
  interval: "month",
  geo: "US,GB,DE",
  plans: "Bronze Plan"
)
```