### PR TITLE
Retrieve specified CCR metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,20 @@ Chartmogul::Metric.cc_metrics(
 )
 ```
 
+#### Retrieve Customer Churn Rate
+
+Retrieve the Customer Churn Rate, for the specified time period.
+
+```ruby
+Chartmogul::Metric.ccr_metrics(
+  start_date: "2015-05-12",
+  end_date: "2015-05-12",
+  interval: "month",
+  geo: "US,GB,DE",
+  plans: "Bronze Plan"
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/metric.rb
+++ b/lib/chartmogul/metric.rb
@@ -3,6 +3,7 @@ require "chartmogul/metrics/key_metric"
 require "chartmogul/metrics/mrr_metric"
 require "chartmogul/metrics/arr_metric"
 require "chartmogul/metrics/asp_metric"
+require "chartmogul/metrics/ccr_metric"
 require "chartmogul/metrics/arpa_metric"
 require "chartmogul/metrics/customer_count"
 

--- a/lib/chartmogul/metrics/ccr_metric.rb
+++ b/lib/chartmogul/metrics/ccr_metric.rb
@@ -1,0 +1,17 @@
+module Chartmogul
+  module Metric
+    class CCRMetric < Base
+      private
+
+      def end_point
+        "customer-churn-rate"
+      end
+    end
+
+    def self.ccr_metrics(start_date:, end_date:, **options)
+      CCRMetric.retrieve(
+        start_date: start_date, end_date: end_date, **options
+      )
+    end
+  end
+end

--- a/spec/chartmogul/metric_spec.rb
+++ b/spec/chartmogul/metric_spec.rb
@@ -66,6 +66,16 @@ describe Chartmogul::Metric do
     end
   end
 
+  describe ".ccr_metrics" do
+    it "retrieves the customer churn rate metrics" do
+      stub_retrieving_metrics_api("customer-churn-rate", metric_attributes)
+      metrics = Chartmogul::Metric.ccr_metrics(metric_attributes)
+
+      expect(metrics.summary.current).not_to be_nil
+      expect(metrics.entries.first["customer-churn-rate"]).not_to be_nil
+    end
+  end
+
   def metric_attributes
     @metric_attributes ||= {
       start_date: "2015-05-12",

--- a/spec/fixtures/customer-churn-rate_metrics.json
+++ b/spec/fixtures/customer-churn-rate_metrics.json
@@ -1,0 +1,13 @@
+{
+  "entries":[
+    {
+      "date":"2015-01-31",
+      "customer-churn-rate":9.8
+    }
+  ],
+  "summary":{
+    "current":9.8,
+    "previous":8.5,
+    "percentage-change":2
+  }
+}


### PR DESCRIPTION
Retrieve the Customer Churn Rate, for the specified time period. Usages:

```ruby
Chartmogul::Metric.ccr_metrics(
  start_date: "2015-05-12",
  end_date: "2015-05-12",
  interval: "month",
  geo: "US,GB,DE",
  plans: "Bronze Plan"
)
```