### PR TITLE
Retrieve specified MRRCR metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,19 @@ Retrieve the Customer Churn Rate, for the specified time period.
 Chartmogul::Metric.ccr_metrics(
   start_date: "2015-05-12",
   end_date: "2015-05-12",
-  interval: "month",
+  geo: "US,GB,DE",
+  plans: "Bronze Plan"
+)
+```
+
+#### Retrieve MRR Churn Rate
+
+Retrieve the Net MRR Churn Rate, for the specified time period.
+
+```ruby
+Chartmogul::Metric.mrrcr_metrics(
+  start_date: "2015-05-12",
+  end_date: "2015-05-12",
   geo: "US,GB,DE",
   plans: "Bronze Plan"
 )

--- a/lib/chartmogul/metric.rb
+++ b/lib/chartmogul/metric.rb
@@ -5,6 +5,7 @@ require "chartmogul/metrics/arr_metric"
 require "chartmogul/metrics/asp_metric"
 require "chartmogul/metrics/ccr_metric"
 require "chartmogul/metrics/arpa_metric"
+require "chartmogul/metrics/mrrcr_metric"
 require "chartmogul/metrics/customer_count"
 
 module Chartmogul

--- a/lib/chartmogul/metrics/mrrcr_metric.rb
+++ b/lib/chartmogul/metrics/mrrcr_metric.rb
@@ -1,0 +1,17 @@
+module Chartmogul
+  module Metric
+    class MRRCRMetric < Base
+      private
+
+      def end_point
+        "mrr-churn-rate"
+      end
+    end
+
+    def self.mrrcr_metrics(start_date:, end_date:, **options)
+      MRRCRMetric.retrieve(
+        start_date: start_date, end_date: end_date, **options
+      )
+    end
+  end
+end

--- a/spec/chartmogul/metric_spec.rb
+++ b/spec/chartmogul/metric_spec.rb
@@ -76,6 +76,16 @@ describe Chartmogul::Metric do
     end
   end
 
+  describe ".mrrcr_metrics" do
+    it "retrieves the net MRR churn rate metrics" do
+      stub_retrieving_metrics_api("mrr-churn-rate", metric_attributes)
+      metrics = Chartmogul::Metric.mrrcr_metrics(metric_attributes)
+
+      expect(metrics.summary.current).not_to be_nil
+      expect(metrics.entries.first["mrr-churn-rate"]).not_to be_nil
+    end
+  end
+
   def metric_attributes
     @metric_attributes ||= {
       start_date: "2015-05-12",

--- a/spec/fixtures/mrr-churn-rate_metrics.json
+++ b/spec/fixtures/mrr-churn-rate_metrics.json
@@ -1,0 +1,17 @@
+{
+  "entries":[
+    {
+      "date":"2015-01-31",
+      "mrr-churn-rate":-300.0
+    },
+    {
+      "date":"2015-02-28",
+      "mrr-churn-rate":-0.0
+    }
+  ],
+  "summary":{
+    "current":0,
+    "previous":0,
+    "percentage-change":0.0
+  }
+}


### PR DESCRIPTION
Retrieve the Net MRR Churn Rate, for the specified time period. Usages:

```ruby
Chartmogul::Metric.mrrcr_metrics(
  start_date: "2015-05-12",
  end_date: "2015-05-12",
  geo: "US,GB,DE",
  plans: "Bronze Plan"
)
```