### PR TITLE
Update Enrichment for API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ ChartMogul, and leverage the powerful segmentation features that we offer.
 Retrieve a customer object from your ChartMogul account.
 
 ```ruby
-Chartmogul::Enrichment::Customer.find("customer_id")
+Chartmogul::Enrichment::Customer.find("customer_uuid")
 ```
 
 #### Search for Customers
@@ -308,7 +308,7 @@ Retrieve the list of attributes for a given customer.
 
 ```ruby
 Chartmogul::Enrichment::Attribute.list(
-  customer_id: customer_id
+  customer_uuid: customer_uuid
 )
 ```
 
@@ -327,7 +327,7 @@ unstructured information on a `customer` object.
 # pass an Array as `tag: ["tag_one", "tag_two", "tag_three"]`
 
 Chartmogul::Enrichment::Tag.create(
-  customer_id: customer_id, tag: "important"
+  customer_uuid: customer_uuid, tag: "important"
 )
 ```
 
@@ -357,7 +357,7 @@ Removes tags from a given customer.
 # pass an Array as `tag: ["tag_one", "tag_two", "tag_three"]`
 
 Chartmogul::Enrichment::Tag.delete(
-  customer_id: customer_id, tag: "important"
+  customer_uuid: customer_uuid, tag: "important"
 )
 ```
 
@@ -378,7 +378,7 @@ Adds custom attributes to a given customer.
 # an Array as `attribute: [attribute_hash, another_attribute_hash]`
 
 Chartmogul::Enrichment::CustomAttribute.create(
-  customer_id: customer_id,
+  customer_uuid: customer_uuid,
   attribute: {
     type: "String",
     key: "channel",
@@ -413,7 +413,7 @@ Update the custom attributes of a given customer.
 
 ```ruby
 Chartmogul::Enrichment::CustomAttribute.update(
-  customer_id: customer_id,
+  customer_uuid: customer_uuid,
   attribute: { key: value, another_key: another_new_value }
 )
 ```
@@ -429,7 +429,7 @@ Removes custom attributes from a given customer.
 # Array as `attribute: ["attribute_key", "another_attribute_key"]`
 
 Chartmogul::Enrichment::CustomAttribute.delete(
-  customer_id: customer_id, attribute: "attribute_key"
+  customer_uuid: customer_uuid, attribute: "attribute_key"
 )
 ```
 

--- a/lib/chartmogul/enrichment/attribute.rb
+++ b/lib/chartmogul/enrichment/attribute.rb
@@ -1,8 +1,8 @@
 module Chartmogul
   module Enrichment
     class Attribute < Base
-      def list(customer_id:)
-        set_customer_id(customer_id)
+      def list(customer_uuid:)
+        set_customer_uuid(customer_uuid)
         list_resource
       end
     end

--- a/lib/chartmogul/enrichment/base.rb
+++ b/lib/chartmogul/enrichment/base.rb
@@ -1,7 +1,7 @@
 module Chartmogul
   module Enrichment
     class Base < Chartmogul::Base
-      attr_reader :customer_id
+      attr_reader :customer_uuid
 
       private
 
@@ -13,20 +13,20 @@ module Chartmogul
       end
 
       def end_point
-        [customer_id, "attributes", resource_key].compact.join("/")
+        [customer_uuid, "attributes", resource_key].compact.join("/")
       end
 
-      def set_customer_id(customer_id)
-        @customer_id = customer_id
+      def set_customer_uuid(customer_uuid)
+        @customer_uuid = customer_uuid
       end
 
-      def create_customer_metadata(customer_id, email, attribute)
-        set_customer_id(customer_id)
+      def create_customer_metadata(customer_uuid, email, attribute)
+        set_customer_uuid(customer_uuid)
         create_resource(build_attributes_hash(attribute, email))
       end
 
-      def delete_customer_metadata(customer_id, attributes)
-        set_customer_id(customer_id)
+      def delete_customer_metadata(customer_uuid, attributes)
+        set_customer_uuid(customer_uuid)
         delete_resource(resource_key.to_sym => build_array(attributes))
       end
 

--- a/lib/chartmogul/enrichment/custom_attribute.rb
+++ b/lib/chartmogul/enrichment/custom_attribute.rb
@@ -1,17 +1,17 @@
 module Chartmogul
   module Enrichment
     class CustomAttribute < Base
-      def create(attribute:, customer_id: nil, email: nil)
-        create_customer_metadata(customer_id, email, attribute)
+      def create(attribute:, customer_uuid: nil, email: nil)
+        create_customer_metadata(customer_uuid, email, attribute)
       end
 
-      def update(customer_id:, attribute:)
-        set_customer_id(customer_id)
+      def update(customer_uuid:, attribute:)
+        set_customer_uuid(customer_uuid)
         update_resource(custom: attribute)
       end
 
-      def delete(customer_id:, attribute:)
-        delete_customer_metadata(customer_id, attribute)
+      def delete(customer_uuid:, attribute:)
+        delete_customer_metadata(customer_uuid, attribute)
       end
 
       private

--- a/lib/chartmogul/enrichment/customer.rb
+++ b/lib/chartmogul/enrichment/customer.rb
@@ -5,8 +5,8 @@ module Chartmogul
         list_resource(options)
       end
 
-      def find(customer_id)
-        set_customer_id(customer_id)
+      def find(customer_uuid)
+        set_customer_uuid(customer_uuid)
         Chartmogul.get_resource(resource_end_point)
       end
 
@@ -17,7 +17,7 @@ module Chartmogul
       private
 
       def end_point
-        customer_id
+        customer_uuid
       end
 
       def search_end_point

--- a/lib/chartmogul/enrichment/tag.rb
+++ b/lib/chartmogul/enrichment/tag.rb
@@ -1,12 +1,12 @@
 module Chartmogul
   module Enrichment
     class Tag < Base
-      def create(tag:, customer_id: nil, email: nil)
-        create_customer_metadata(customer_id, email, tag)
+      def create(tag:, customer_uuid: nil, email: nil)
+        create_customer_metadata(customer_uuid, email, tag)
       end
 
-      def delete(customer_id:, tag:)
-        delete_customer_metadata(customer_id, tag)
+      def delete(customer_uuid:, tag:)
+        delete_customer_metadata(customer_uuid, tag)
       end
 
       private

--- a/spec/chartmogul/enrichment/attribute_spec.rb
+++ b/spec/chartmogul/enrichment/attribute_spec.rb
@@ -3,11 +3,11 @@ require "spec_helper"
 describe Chartmogul::Enrichment::Attribute do
   describe ".list" do
     it "retrieves a given customer attributes" do
-      customer_id = "customer_id_001"
+      customer_uuid = "customer_uuid_001"
 
-      stub_customer_attribute_list_api(customer_id)
+      stub_customer_attribute_list_api(customer_uuid)
       attributes = Chartmogul::Enrichment::Attribute.list(
-        customer_id: customer_id
+        customer_uuid: customer_uuid
       )
 
       expect(attributes.attributes.custom[:CAC]).to eq(213)

--- a/spec/chartmogul/enrichment/custom_attribute_spec.rb
+++ b/spec/chartmogul/enrichment/custom_attribute_spec.rb
@@ -2,10 +2,10 @@ require "spec_helper"
 
 describe Chartmogul::Enrichment::CustomAttribute do
   describe ".create" do
-    context "when customer id and attribute provided" do
+    context "when customer uuid and attribute provided" do
       it "adds a custom attribute to the customer" do
         custom_attrubute_hash = {
-          customer_id: "customer_id_001", attribute: attribute
+          customer_uuid: "customer_uuid_001", attribute: attribute
         }
 
         stub_custom_attribute_create_api(custom_attrubute_hash)
@@ -38,7 +38,7 @@ describe Chartmogul::Enrichment::CustomAttribute do
   describe ".update" do
     it "updates customer's custom attributes" do
       custom_attrubute_hash = {
-        customer_id: "customer_id_001", attribute: { channel: "Twitter" }
+        customer_uuid: "customer_uuid_001", attribute: { channel: "Twitter" }
       }
 
       stub_custom_attribute_update_api(custom_attrubute_hash)
@@ -54,7 +54,7 @@ describe Chartmogul::Enrichment::CustomAttribute do
   describe ".delete" do
     it "removes custom attributes from the customer" do
       custom_attrubute_hash = {
-        customer_id: "customer_id_001", attribute: "channel"
+        customer_uuid: "customer_uuid_001", attribute: "channel"
       }
 
       stub_custom_attribute_delete_api(custom_attrubute_hash)

--- a/spec/chartmogul/enrichment/customer_spec.rb
+++ b/spec/chartmogul/enrichment/customer_spec.rb
@@ -3,12 +3,12 @@ require "spec_helper"
 describe Chartmogul::Enrichment::Customer do
   describe ".find" do
     it "retrieves a customer details" do
-      customer_id = "customer_id_001"
+      customer_uuid = "customer_uuid_001"
 
-      stub_customer_find_api(customer_id)
-      customer = Chartmogul::Enrichment::Customer.find(customer_id)
+      stub_customer_find_api(customer_uuid)
+      customer = Chartmogul::Enrichment::Customer.find(customer_uuid)
 
-      expect(customer.id).to eq(customer_id)
+      expect(customer.uuid).to eq(customer_uuid)
       expect(customer.status).to eq("Active")
       expect(customer.name).to eq("Adam Smith")
       expect(customer["billing-system-type"]).to eq("Stripe")

--- a/spec/chartmogul/enrichment/tag_spec.rb
+++ b/spec/chartmogul/enrichment/tag_spec.rb
@@ -2,10 +2,10 @@ require "spec_helper"
 
 describe Chartmogul::Enrichment::Tag do
   describe ".create" do
-    context "when customer id and tags provided" do
+    context "when customer uuid and tags provided" do
       it "adds a new tag to the customer" do
         tag_attributes = {
-          customer_id: "customer_id_001", tag: "important"
+          customer_uuid: "customer_uuid_001", tag: "important"
         }
 
         stub_customer_tag_create_api(tag_attributes)
@@ -33,7 +33,7 @@ describe Chartmogul::Enrichment::Tag do
 
   describe ".remove" do
     it "removes the specified tag from customer" do
-      tag_attributes = { customer_id: "customer_id_001", tag: "important" }
+      tag_attributes = { customer_uuid: "customer_uuid_001", tag: "important" }
 
       stub_customer_tag_delete_api(tag_attributes)
       tags = Chartmogul::Enrichment::Tag.delete(tag_attributes)

--- a/spec/fixtures/customer.json
+++ b/spec/fixtures/customer.json
@@ -1,6 +1,6 @@
 {
   "id": "customer_id_001",
-  "uuid": "cus_de305d54-75b4-431b-adb2-eb6b9e546012",
+  "uuid": "customer_uuid_001",
   "external_id": "34916129",
   "name": "Adam Smith",
   "email": "bob@examplecompany.com",

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -149,10 +149,10 @@ module FakeChartmogulApi
     )
   end
 
-  def stub_customer_tag_create_api(customer_id:, tag:)
+  def stub_customer_tag_create_api(customer_uuid:, tag:)
     stub_api_response(
       :post,
-      ["customers", customer_id, "attributes", "tags"].join("/"),
+      ["customers", customer_uuid, "attributes", "tags"].join("/"),
       data: { tags: [tag] },
       filename: "tag_created",
       status: 200
@@ -169,20 +169,20 @@ module FakeChartmogulApi
     )
   end
 
-  def stub_customer_tag_delete_api(customer_id:, tag:)
+  def stub_customer_tag_delete_api(customer_uuid:, tag:)
     stub_api_response(
       :delete,
-      ["customers", customer_id, "attributes", "tags"].join("/"),
+      ["customers", customer_uuid, "attributes", "tags"].join("/"),
       data: { tags: [tag] },
       filename: "tag_deleted",
       status: 200
     )
   end
 
-  def stub_custom_attribute_create_api(customer_id:, attribute:)
+  def stub_custom_attribute_create_api(customer_uuid:, attribute:)
     stub_api_response(
       :post,
-      ["customers", customer_id, "attributes", "custom"].join("/"),
+      ["customers", customer_uuid, "attributes", "custom"].join("/"),
       data: { custom: [attribute] },
       filename: "custom_attribute_created",
       status: 200
@@ -199,20 +199,20 @@ module FakeChartmogulApi
     )
   end
 
-  def stub_custom_attribute_update_api(customer_id:, attribute:)
+  def stub_custom_attribute_update_api(customer_uuid:, attribute:)
     stub_api_response(
       :put,
-      ["customers", customer_id, "attributes", "custom"].join("/"),
+      ["customers", customer_uuid, "attributes", "custom"].join("/"),
       data: { custom: attribute },
       filename: "custom_attribute_updated",
       status: 200
     )
   end
 
-  def stub_custom_attribute_delete_api(customer_id:, attribute:)
+  def stub_custom_attribute_delete_api(customer_uuid:, attribute:)
     stub_api_response(
       :delete,
-      ["customers", customer_id, "attributes", "custom"].join("/"),
+      ["customers", customer_uuid, "attributes", "custom"].join("/"),
       data: { custom: [attribute] },
       filename: "custom_attribute_deleted",
       status: 200


### PR DESCRIPTION
Recently, ChartMogul updated their enrichment API to use `customer_uuid` instead of `customer_id`. Although `customer_id` still works but it might be deprecated soon, so let's update our enrichment module for the API changes.