### PR TITLE
Listing customer's subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,18 @@ Chartmogul::Metric.ltv_metrics(
 )
 ```
 
+### Customers
+
+#### List Customer Subscriptions
+
+Retrieve a list of subscriptions for a given customer.
+
+```ruby
+Chartmogul:Metric::Subscription.list(
+  customer_uuid: "customer_uuid_001", **listing_options
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/metric.rb
+++ b/lib/chartmogul/metric.rb
@@ -1,4 +1,5 @@
 require "chartmogul/metrics/base"
+require "chartmogul/metrics/subscription"
 
 module Chartmogul
   module Metric

--- a/lib/chartmogul/metrics/subscription.rb
+++ b/lib/chartmogul/metrics/subscription.rb
@@ -1,0 +1,22 @@
+module Chartmogul
+  module Metric
+    class Subscription < Chartmogul::Base
+      attr_reader :customer_uuid
+
+      def list(customer_uuid:, **options)
+        @customer_uuid = customer_uuid
+        list_resource(options)
+      end
+
+      private
+
+      def end_point
+        [customer_uuid, "subscriptions"].join("/")
+      end
+
+      def resource_base
+        "customers"
+      end
+    end
+  end
+end

--- a/spec/chartmogul/metrics/subscription_spec.rb
+++ b/spec/chartmogul/metrics/subscription_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe Chartmogul::Metric::Subscription do
+  describe ".list" do
+    it "lists the given customer's subscriptions" do
+      customer_uuid = "customer_uuid_001"
+
+      stub_customer_subscriptions_list_api(customer_uuid)
+      subscriptions = Chartmogul::Metric::Subscription.list(
+        customer_uuid: customer_uuid
+      )
+
+      expect(subscriptions.page).to eq(1)
+      expect(subscriptions.entries.count).to eq(1)
+      expect(subscriptions.entries.first.plan).not_to be_nil
+    end
+  end
+end

--- a/spec/fixtures/customer_subscriptions.json
+++ b/spec/fixtures/customer_subscriptions.json
@@ -1,0 +1,21 @@
+{
+  "entries": [
+    {
+      "id": 9306830,
+      "plan": "PRO Plan (10,000 active cust.) monthly",
+      "quantity": 1,
+      "mrr": 70800,
+      "arr": 849600,
+      "status": "active",
+      "billing-cycle": "month",
+      "billing-cycle-count": 1,
+      "start-date": "2015-12-20T08:26:49-05:00",
+      "end-date": "2016-03-20T09:26:49-05:00",
+      "currency": "USD",
+      "currency-sign": "$"
+    }
+  ],
+  "has_more": false,
+  "per_page": 200,
+  "page": 1
+}

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -228,6 +228,15 @@ module FakeChartmogulApi
     )
   end
 
+  def stub_customer_subscriptions_list_api(customer_uuid)
+    stub_api_response(
+      :get,
+      ["customers", customer_uuid, "subscriptions"].join("/"),
+      filename: "customer_subscriptions",
+      status: 200
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status: 200, data: nil)


### PR DESCRIPTION
Retrieve the list of subscriptions for a given customer. Usages:

```ruby
Chartmogul:Metric::Subscription.list(
  customer_uuid: "customer_uuid_001"
)
```