### PR TITLE
Listing customer's activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,16 @@ Chartmogul:Metric::Subscription.list(
 )
 ```
 
+#### List Customer Activities
+
+Retrieve a list of activities for a given customer.
+
+```ruby
+Chartmogul::Metric::Activity.list(
+  customer_uuid: "customer_uuid_001", **listing_options
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the

--- a/lib/chartmogul/metric.rb
+++ b/lib/chartmogul/metric.rb
@@ -1,4 +1,6 @@
 require "chartmogul/metrics/base"
+require "chartmogul/metrics/customer"
+require "chartmogul/metrics/activity"
 require "chartmogul/metrics/subscription"
 
 module Chartmogul

--- a/lib/chartmogul/metrics/activity.rb
+++ b/lib/chartmogul/metrics/activity.rb
@@ -1,10 +1,10 @@
 module Chartmogul
   module Metric
-    class Subscription < Customer
+    class Activity < Customer
       private
 
       def end_point
-        "subscriptions"
+        "activities"
       end
     end
   end

--- a/lib/chartmogul/metrics/customer.rb
+++ b/lib/chartmogul/metrics/customer.rb
@@ -1,0 +1,18 @@
+module Chartmogul
+  module Metric
+    class Customer < Chartmogul::Base
+      attr_reader :customer_uuid
+
+      def list(customer_uuid:, **listing_options)
+        @customer_uuid = customer_uuid
+        list_resource(listing_options)
+      end
+
+      private
+
+      def resource_base
+        ["customers", customer_uuid].join("/")
+      end
+    end
+  end
+end

--- a/spec/chartmogul/metrics/activity_spec.rb
+++ b/spec/chartmogul/metrics/activity_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe Chartmogul::Metric::Activity do
+  describe ".list" do
+    it "lists the given customer activities" do
+      customer_uuid = "customer_uuid_001"
+
+      stub_customer_metric_listing_api("activities", customer_uuid)
+      activities = Chartmogul::Metric::Activity.list(
+        customer_uuid: customer_uuid
+      )
+
+      expect(activities.page).to eq(1)
+      expect(activities.entries.first.currency).to eq("USD")
+      expect(activities.entries.first["activity-arr"]).to eq(240_00)
+    end
+  end
+end

--- a/spec/chartmogul/metrics/subscription_spec.rb
+++ b/spec/chartmogul/metrics/subscription_spec.rb
@@ -5,7 +5,7 @@ describe Chartmogul::Metric::Subscription do
     it "lists the given customer's subscriptions" do
       customer_uuid = "customer_uuid_001"
 
-      stub_customer_subscriptions_list_api(customer_uuid)
+      stub_customer_metric_listing_api("subscriptions", customer_uuid)
       subscriptions = Chartmogul::Metric::Subscription.list(
         customer_uuid: customer_uuid
       )

--- a/spec/fixtures/customer_activities.json
+++ b/spec/fixtures/customer_activities.json
@@ -1,0 +1,18 @@
+{
+  "entries":[
+    {
+      "activity-arr": 24000,
+      "activity-mrr": 2000,
+      "activity-mrr-movement": 2000,
+      "currency": "USD",
+      "currency-sign": "$",
+      "date": "2015-06-09T13:16:00-04:00",
+      "description": "purchased the Silver Monthly plan (1)",
+      "id": 48730,
+      "type": "new_biz"
+    }
+  ],
+  "has_more":false,
+  "per_page":200,
+  "page":1
+}

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -228,11 +228,11 @@ module FakeChartmogulApi
     )
   end
 
-  def stub_customer_subscriptions_list_api(customer_uuid)
+  def stub_customer_metric_listing_api(resource_type, customer_uuid)
     stub_api_response(
       :get,
-      ["customers", customer_uuid, "subscriptions"].join("/"),
-      filename: "customer_subscriptions",
+      ["customers", customer_uuid, resource_type].join("/"),
+      filename: ["customer", resource_type].join("_"),
       status: 200
     )
   end


### PR DESCRIPTION
Returns the list of activities for a given customer. Usages:

```ruby
Chartmogul::Metric::Activity.list(
  customer_uuid: "customer_uuid_001"
)
```