### PR TITLE
Add configurable response type

### DIFF
--- a/.sample.pryrc
+++ b/.sample.pryrc
@@ -1,4 +1,5 @@
 Chartmogul.configure do |config|
   config.account_token = CM_ACCOUNT_TOKEN
   config.secret_key = CM_SECRET_KEY
+  config.response_type = "object"
 end

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ to set your API keys
 Chartmogul.configure do |config|
   config.account_token = "YOUR_ACCOUNT_TOKEN"
   config.secret_key = "YOUR_SECRET_KEY"
+
+  # Default configurations
+  # config.api_host = "https://api.chartmogul.com/v1"
+  # config.response_type = "object" [alternative: "hash"]
 end
 ```
 

--- a/lib/chartmogul/configuration.rb
+++ b/lib/chartmogul/configuration.rb
@@ -1,9 +1,27 @@
 module Chartmogul
   class Configuration
-    attr_accessor :api_host, :account_token, :secret_key
+    attr_accessor :api_host, :response_type
+    attr_accessor :account_token, :secret_key
 
     def initialize
       @api_host ||= "https://api.chartmogul.com/v1"
+      @response_type ||= :object
+    end
+
+    def response_klass
+      response_object || Hash
+    end
+
+    private
+
+    def response_object
+      if response_as_object?
+        ResponseObject
+      end
+    end
+
+    def response_as_object?
+      response_type.to_s.casecmp("object") == 0
     end
   end
 

--- a/lib/chartmogul/response.rb
+++ b/lib/chartmogul/response.rb
@@ -3,9 +3,13 @@ require "json"
 module Chartmogul
   class Response
     def self.parse_json(response)
-      JSON.parse(response, object_class: OpenStruct)
+      JSON.parse(
+        response, object_class: Chartmogul.configuration.response_klass
+      )
     rescue TypeError, JSON::ParserError
       response
     end
   end
+
+  class ResponseObject < OpenStruct; end
 end

--- a/spec/chartmogul/configuration_spec.rb
+++ b/spec/chartmogul/configuration_spec.rb
@@ -38,4 +38,13 @@ describe Chartmogul::Configuration do
       end
     end
   end
+
+  describe ".response_klass" do
+    context "when response_type set to :hash" do
+      it "usages it as response base class" do
+        Chartmogul.configure { |config| config.response_type = :hash }
+        expect(Chartmogul.configuration.response_klass).to eq(Hash)
+      end
+    end
+  end
 end

--- a/spec/chartmogul/response_spec.rb
+++ b/spec/chartmogul/response_spec.rb
@@ -2,11 +2,29 @@ require "spec_helper"
 
 describe Chartmogul::Response do
   describe ".parse_json" do
-    it "parse json response" do
-      json_content = File.read "./spec/fixtures/ping.json"
-      response_object = Chartmogul::Response.parse_json(json_content)
+    context "when response type set to hash" do
+      it "parses the content to Hash" do
+        response = api_response_for(type: :hash)
 
-      expect(response_object.data).to eq("pong!")
+        expect(response.class).to eq(Hash)
+        expect(response["data"]).to eq("pong!")
+      end
     end
+
+    context "when response type set to object" do
+      it "parses the content to ResponseObject" do
+        response = api_response_for(type: :object)
+
+        expect(response.data).to eq("pong!")
+        expect(response.class).to eq(Chartmogul::ResponseObject)
+      end
+    end
+  end
+
+  def api_response_for(type:)
+    Chartmogul.configuration.response_type = type
+    json_content = File.read "./spec/fixtures/ping.json"
+
+    Chartmogul::Response.parse_json(json_content)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ RSpec.configure do |config|
       Chartmogul.configure do |chartmogul_config|
         chartmogul_config.account_token = "ACCOUNT_TOKEN"
         chartmogul_config.secret_key = "ACCOUNT_SECRET_KEY"
+        chartmogul_config.response_type = :object
       end
     end
   end


### PR DESCRIPTION
We have been using `OpenStruct` to parse the API responses to an object. Normally `OpenStruct` is slower in performance. The amount of data our API client will be dealing is not that large so technically it should not effect at all.

But let's change it be configurable so user can use it based on their necessity.