### PR TITLE
Rename confusing parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ from these invoices. Ref: [Create Invoice API]
 # Array as `invoice: [invoice_attributes, another_invoice_attributes]`
 
 Chartmogul::Import::Invoice.create(
-  uuid: customer_uuid, invoice: invoice_attributes
+  customer_uuid: customer_uuid, invoice: invoice_attributes
 )
 
 # Pay close attention to the construction of this object.
@@ -212,7 +212,7 @@ List the invoices of a specified customer
 
 ```ruby
 Chartmogul::Import::Invoice.list(
-  uuid: customer_uuid, page: 1, per_page: 20
+  customer_uuid: customer_uuid, page: 1, per_page: 20
 )
 ```
 
@@ -230,7 +230,7 @@ Create a new transaction object for an invoice imported using the Import API.
 ```ruby
 Chartmogul::Import::Transaction.create(
   type: "refund",
-  uuid: "invoice_001",
+  invoice_uuid: "invoice_uuid_001",
   result: "successful",
   date: "2015-12-25 18:10:00",
   external_id: "transaction_001"
@@ -251,7 +251,7 @@ are auto-generated from invoice objects created using the Import API.
 
 ```ruby
 Chartmogul::Import::Subscription.list(
-  uuid: "customer_uuid_001", page: 1, per_page: 10
+  customer_uuid: "customer_uuid_001", page: 1, per_page: 10
 )
 ```
 

--- a/lib/chartmogul/import/invoice.rb
+++ b/lib/chartmogul/import/invoice.rb
@@ -3,13 +3,13 @@ module Chartmogul
     class Invoice < Base
       attr_accessor :customer_uuid
 
-      def list(uuid:, **listing_options)
-        @customer_uuid = uuid
+      def list(customer_uuid:, **listing_options)
+        @customer_uuid = customer_uuid
         super(listing_options)
       end
 
-      def create(uuid:, invoice:)
-        @customer_uuid = uuid
+      def create(customer_uuid:, invoice:)
+        @customer_uuid = customer_uuid
         super(invoices: build_array(invoice))
       end
 

--- a/lib/chartmogul/import/subscription.rb
+++ b/lib/chartmogul/import/subscription.rb
@@ -3,8 +3,8 @@ module Chartmogul
     class Subscription < Base
       attr_reader :customer_uuid
 
-      def list(uuid:, **listing_options)
-        @customer_uuid = uuid
+      def list(customer_uuid:, **listing_options)
+        @customer_uuid = customer_uuid
         super(listing_options)
       end
 

--- a/lib/chartmogul/import/transaction.rb
+++ b/lib/chartmogul/import/transaction.rb
@@ -3,8 +3,8 @@ module Chartmogul
     class Transaction < Base
       attr_reader :invoice_uuid
 
-      def create(uuid:, **transaction_attributes)
-        @invoice_uuid = uuid
+      def create(invoice_uuid:, **transaction_attributes)
+        @invoice_uuid = invoice_uuid
         super(transaction_attributes)
       end
 

--- a/spec/chartmogul/import/invoice_spec.rb
+++ b/spec/chartmogul/import/invoice_spec.rb
@@ -4,7 +4,7 @@ describe Chartmogul::Import::Invoice do
   describe ".list" do
     it "lists existing invoices" do
       customer_uuid = "customer_001"
-      listing_options = { uuid: customer_uuid, page: 1, per_page: 1 }
+      listing_options = { customer_uuid: customer_uuid, page: 1, per_page: 1 }
 
       stub_invoice_listing_api(listing_options)
       invoices = Chartmogul::Import::Invoice.list(listing_options)
@@ -30,7 +30,7 @@ describe Chartmogul::Import::Invoice do
 
       stub_invoice_create_api(customer_uuid, invoices: [invoice_attributes])
       invoices = Chartmogul::Import::Invoice.create(
-        uuid: customer_uuid, invoice: invoice_attributes
+        customer_uuid: customer_uuid, invoice: invoice_attributes
       )
 
       expect(invoices.invoices.first.uuid).not_to be_nil

--- a/spec/chartmogul/import/subscription_spec.rb
+++ b/spec/chartmogul/import/subscription_spec.rb
@@ -3,7 +3,9 @@ require "spec_helper"
 describe Chartmogul::Import::Subscription do
   describe ".list" do
     it "lists customer subscriptions" do
-      listing_options = { uuid: "customer_001", page: 1, per_page: 1 }
+      listing_options = {
+        customer_uuid: "customer_uuid_001", page: 1, per_page: 1
+      }
 
       stub_subscription_listing_api(listing_options)
       subscriptions = Chartmogul::Import::Subscription.list(listing_options)
@@ -11,7 +13,7 @@ describe Chartmogul::Import::Subscription do
       expect(subscriptions.current_page).to eq(1)
       expect(subscriptions.subscriptions.first.uuid).not_to be_nil
       expect(subscriptions.subscriptions.first.plan_uuid).not_to be_nil
-      expect(subscriptions.customer_uuid).to eq(listing_options[:uuid])
+      expect(subscriptions.customer_uuid).to eq(listing_options[:customer_uuid])
     end
   end
 

--- a/spec/chartmogul/import/transaction_spec.rb
+++ b/spec/chartmogul/import/transaction_spec.rb
@@ -5,7 +5,7 @@ describe Chartmogul::Import::Transaction do
     it "creates a new transaction for a invoice" do
       transaction_attributes = {
         type: "refund",
-        uuid: "invoice_001",
+        invoice_uuid: "invoice_001",
         result: "successful",
         date: "2015-12-25 18:10:00",
         external_id: "transaction_001"

--- a/spec/fixtures/subscription_list.json
+++ b/spec/fixtures/subscription_list.json
@@ -1,5 +1,5 @@
 {
-  "customer_uuid": "customer_001",
+  "customer_uuid": "customer_uuid_001",
   "subscriptions":[
     {
       "uuid": "sub_e6bc5407-e258-4de0-bb43",

--- a/spec/support/fake_chartmogul_api.rb
+++ b/spec/support/fake_chartmogul_api.rb
@@ -75,29 +75,35 @@ module FakeChartmogulApi
     )
   end
 
-  def stub_invoice_listing_api(uuid:, **listing_options)
+  def stub_invoice_listing_api(customer_uuid:, **listing_options)
     stub_api_response(
       :get,
-      [invoice_end_point(uuid), resource_params(listing_options)].join("?"),
+      [
+        invoice_end_point(customer_uuid),
+        resource_params(listing_options)
+      ].join("?"),
       filename: "invoice_list",
       status: 200
     )
   end
 
-  def stub_transaction_create_api(uuid:, **attributes)
+  def stub_transaction_create_api(invoice_uuid:, **attributes)
     stub_api_response(
       :post,
-      transaction_end_point(uuid),
+      transaction_end_point(invoice_uuid),
       data: attributes,
       filename: "transaction_created",
       status: 201
     )
   end
 
-  def stub_subscription_listing_api(uuid:, **options)
+  def stub_subscription_listing_api(customer_uuid:, **options)
     stub_api_response(
       :get,
-      [subscription_end_point(uuid), resource_params(options)].join("?"),
+      [
+        subscription_end_point(customer_uuid),
+        resource_params(options)
+      ].join("?"),
       filename: "subscription_list",
       status: 200
     )


### PR DESCRIPTION
There were couple of confusing public api parameters which might create confusion for users. This commit changes those parameter name to be more readable

* Invoice create/list `uuid` parameter to `customer_uuid`
* Transaction creation `uuid` parameter to `invoice_uuid`
* Subscription creation `uuid` parameter to `customer_uuid`